### PR TITLE
fix: update deprecated node version to fix warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
   steps:
     - name: Docker meta
       id: docker_meta
-      uses: crazy-max/ghaction-docker-meta@v5
+      uses: docker/metadata-action@v5
       with:
         images: |
           ${{ inputs.docker-registry }}/${{ inputs.docker-base-image-path }}/${{ github.repository }}/${{ inputs.docker-target }}
@@ -69,7 +69,7 @@ runs:
         password: "${{ steps.auth.outputs.access_token }}"
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         push: ${{ inputs.push }}
         network: host


### PR DESCRIPTION
This removes some build warnings related to deprecated node version. However I am not sure if our self-hosted runner supports the Actions Runner v2.308.0


    Node 20 as default runtime (requires [Actions Runner v2.308.0](https://github.com/actions/runner/releases/tag/v2.308.0) or later)
    https://github.com/docker/build-push-action/releases/tag/v5.0.0

WARNING: [Build-And-Publish (ml-tcp-trainer)](https://github.com/redcarbon-dev/rc-python-mono/actions/runs/8016359806/job/21898152543)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: docker/build-push-action@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.